### PR TITLE
Classloading improvements (#10)

### DIFF
--- a/src/main/java/me/rojo8399/placeholderapi/Registry.java
+++ b/src/main/java/me/rojo8399/placeholderapi/Registry.java
@@ -37,6 +37,9 @@ public class Registry {
 	}
 
 	public Expansion get(String id) {
+		if (!has(id)) {
+			return null;
+		}
 		return getEntry(id).getExpansion();
 	}
 


### PR DESCRIPTION
* Forgot to make the Entries immutable

* More support for Text.

TODO have expansion support text output and ditch strings altogether?

Also working on loading external placeholders though the method I tried
to use doesn't work.

* Several changes

Added list and info commands:
- List all registered placeholders
- Get info on a registered placeholder

Added service methods getExpansion(id) and getExpansions()

Got class loading to work via sketchy reflection. Now expansion.class
files can be loaded from the /expansions folder in the PAPI config
folder.

* Improvements to classloading

Now compiles .java files into .class files.
Skips over files with already loaded placeholder classes.

Fixed NPE.

Made class loading async so as to lower burden on game loading.